### PR TITLE
fix when frames.length = 0

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -503,9 +503,9 @@ VideoSegmentStream = function(track) {
 
     // For the last frame, use the duration of the previous frame if we
     // have nothing better to go on
-    if (frames.length &&
+    if (frames.length && (
         !currentFrame.duration ||
-        currentFrame.duration <= 0) {
+        currentFrame.duration <= 0)) {
       currentFrame.duration = frames[frames.length - 1].duration;
     }
 


### PR DESCRIPTION
if frames.length === 0 you can not use frames[frames.length - 1]
